### PR TITLE
fix: Resolve compilation errors after WebSocket refactoring

### DIFF
--- a/trello/realtime/hub.go
+++ b/trello/realtime/hub.go
@@ -31,6 +31,17 @@ func NewHub() *Hub {
 	}
 }
 
+// Submit queues a message for broadcast by the hub.
+func (h *Hub) Submit(msg *WebSocketMessage) {
+	// This send is blocking if the broadcast channel is full.
+	// The hub's Run method should process messages from this channel quickly.
+	// If the broadcast channel is buffered, it can absorb some burst.
+	// If this becomes a bottleneck (e.g., services submitting faster than hub can process/broadcast),
+	// consider increasing buffer size of h.broadcast or making this Submit non-blocking
+	// with a select-default, though that might mean dropping messages under heavy load.
+	h.broadcast <- msg
+}
+
 // Run starts the hub's event loop.
 func (h *Hub) Run() {
 	for {

--- a/trello/services/board_service.go
+++ b/trello/services/board_service.go
@@ -77,7 +77,7 @@ func (s *BoardService) CreateBoard(name, description string, ownerID uint) (*mod
 		ownerID,
 	)
 
-	return createdBoard
+	return createdBoard, nil
 }
 
 func (s *BoardService) GetBoardByID(boardID, userID uint) (*models.Board, error) {
@@ -143,7 +143,7 @@ func (s *BoardService) UpdateBoard(boardID uint, name, description *string, user
 		dto.MapBoardToResponse(updatedBoard, true, false), // Use dto mapper
 		userID,
 	)
-	return updatedBoard
+	return updatedBoard, nil
 }
 
 func (s *BoardService) DeleteBoard(boardID, userID uint) error {
@@ -238,7 +238,7 @@ func (s *BoardService) AddMemberToBoard(boardID uint, email *string, memberUserI
 		dto.MapBoardMemberToResponse(addedMember), // Use dto mapper
 		currentUserID,
 	)
-	return addedMember
+	return addedMember, nil
 }
 
 func (s *BoardService) RemoveMemberFromBoard(boardID, memberUserID, currentUserID uint) error {

--- a/trello/services/broadcast_helper.go
+++ b/trello/services/broadcast_helper.go
@@ -33,16 +33,9 @@ func broadcastMessage(
 	}
 
 	// The hub will handle JSON marshalling of the client-facing parts (Type & Payload)
-	// Send the structured message to the hub's broadcast channel
-	select {
-	case hub.Broadcast <- msg:
-		log.Printf("Message of type %s for board %d queued for broadcast.", messageType, boardID)
-	default:
-		// This case should ideally not be hit if the broadcast channel is buffered
-		// or if the hub is processing messages quickly enough.
-		// If hit, it means the hub's broadcast channel is full, which is a bottleneck.
-		log.Printf("Error: Hub broadcast channel full. Failed to queue message type %s for board %d.", messageType, boardID)
-	}
+	// Send the structured message to the hub via its exported method
+	hub.Submit(msg)
+	log.Printf("Message of type %s for board %d submitted to hub.", messageType, boardID)
 }
 
 // --- Payload Mapping Helpers (moved from individual services for reusability if needed) ---

--- a/trello/services/card_service.go
+++ b/trello/services/card_service.go
@@ -132,7 +132,7 @@ func (s *CardService) CreateCard(listID uint, title, description string, positio
 		currentUserID,
 	)
 
-	return createdCard
+	return createdCard, nil
 }
 
 func (s *CardService) GetCardByID(cardID uint, currentUserID uint) (*models.Card, error) {
@@ -326,7 +326,7 @@ func (s *CardService) UpdateCard(
 	}
 
 
-	return updatedCard
+	return updatedCard, nil
 }
 
 func (s *CardService) DeleteCard(cardID uint, currentUserID uint) error {
@@ -435,7 +435,7 @@ func (s *CardService) MoveCard(cardID uint, targetListID uint, newPosition uint,
 		currentUserID,
 	)
 
-	return movedCard
+	return movedCard, nil
 }
 
 // AddCollaboratorToCard adds a user as a collaborator to a card.
@@ -494,7 +494,7 @@ func (s *CardService) AddCollaboratorToCard(cardID uint, currentUserID uint, tar
 			CardID:   cardID,
 			UserID:   targetUser.ID,
 			BoardID:  boardID,
-			UserName: targetUser.Name, // Assuming User model has Name
+			UserName: targetUser.Username, // Corrected line
 		}
 		broadcastMessage(
 			s.hub,

--- a/trello/services/list_service.go
+++ b/trello/services/list_service.go
@@ -102,7 +102,7 @@ func (s *ListService) CreateList(name string, boardID uint, userID uint, positio
 		userID,
 	)
 
-	return createdList
+	return createdList, nil
 }
 
 func (s *ListService) GetListsByBoardID(boardID uint, userID uint) ([]models.List, error) {
@@ -212,7 +212,7 @@ func (s *ListService) UpdateList(listID uint, name *string, newPosition *uint, u
 		userID,
 	)
 
-	return updatedList
+	return updatedList, nil
 }
 
 func (s *ListService) DeleteList(listID uint, userID uint) error {


### PR DESCRIPTION
This commit addresses several compilation errors that arose after the recent refactoring for WebSocket implementation and circular dependency resolution.

1.  **Corrected Return Values in Services:** Ensured that service methods in `board_service.go`, `list_service.go`, and `card_service.go` consistently return `(*models.ModelType, nil)` on successful execution paths, matching their declared function signatures. This resolves various "not enough return values" errors.

2.  **Fixed Hub Broadcast Access:** Modified `realtime/hub.go` to include an exported method for sending messages to the hub's internal broadcast channel. Updated `services/broadcast_helper.go` to use the new exported method instead of attempting to access an unexported channel field directly. This resolves the "hub.Broadcast undefined" error.

3.  **Corrected User Field Name:** In `services/card_service.go`, within the `AddCollaboratorToCard` method, changed `targetUser.Name` to `targetUser.Username` when populating the `CardCollaboratorPayload`. This reflects the actual field name in the `models.User` struct and fixes the "targetUser.Name undefined" error.